### PR TITLE
Make ats importable

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 .env
 __pycache__/
-mapping.json
+.vscode/
+build/
+*.egg-info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["setuptools>=68", "setuptools_scm[toml]>=8"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "AudiobookTextSync"
+version = "1.0.0"
+description = "Core alignment algoritm and wrapper for syncing text to audio"
+readme = "README.md"
+requires-python = ">=3.10"
+license = {file = "LICENSE"}
+
+# Optional metadata
+authors = [{name = "ym1234"}, {name = "KanjiEater", email = "kanjieat3r@gmail.com"}]
+keywords = ["whisper", "subtitles", "align", "generate"]
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Programming Language :: Python :: 3",
+    "License :: OSI Approved :: MIT License",
+]
+
+dependencies = [
+    "beautifulsoup4 ~= 4.12.0",
+    "biopython ~= 1.83",
+    "EbookLib ~= 0.18",
+    "faster_whisper ~= 1.0.1",
+    "ffmpeg_python ~= 0.2.0",
+    "rapidfuzz ~= 3.8.1",
+    "numpy ~= 1.24.3",
+    "openai_whisper == 20231117",
+    "regex ~= 2023.12.25",
+    "tabulate ~= 0.9.0",
+    "tqdm ~= 4.65.0",
+]
+
+[project.scripts]
+"ats" = "scripts:src"

--- a/src/main.py
+++ b/src/main.py
@@ -447,7 +447,7 @@ if __name__ == "__main__":
     model, device = args.pop("model"), args.pop('device')
     if device == 'cuda' and not torch.cuda.is_available():
         device = 'cpu'
-
+    print(f"We're using {device}")
     overwrite, overwrite_cache = args.pop('overwrite'), args.pop('overwrite_cache')
     cache = Cache(model_name=model, enabled=args.pop("use_cache"), cache_dir=args.pop("cache_dir"),
                   ask=not overwrite_cache, overwrite=overwrite_cache,


### PR DESCRIPTION
Without a setup.py or pyproject.toml, we can't import your code.

pyproject.toml allows us to make importable _and_ replaces requirements.txt. I didn't remove the reqs.txt just yet, as I don't want to mess with the collab just yet, but we can do that too whenever you're ready.

To install `pip install .`, so it makes setup a little easier too.

As soon as we merge this i can import it remotely and publish a docker container for this.